### PR TITLE
Disable Kubernetes service links

### DIFF
--- a/deploy/base/backend.yaml
+++ b/deploy/base/backend.yaml
@@ -88,4 +88,5 @@ spec:
             requests:
               cpu: 100m
               memory: 16Mi
+      enableServiceLinks: false
       serviceAccountName: greenstar-backend


### PR DESCRIPTION
This change disables the environment variables created by Kubernetes for available services.

The reason is that those environment variables are conflicting with other CLI configurations we use due to conflicting naming conventions.