### PR TITLE
Remove "app.kubernetes.io/managed-by" label

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 commonLabels:
   app: greenstar
   app.kubernetes.io/name: greenstar
-  app.kubernetes.io/managed-by: kustomize
 resources:
   - backend.yaml
   - frontend.yaml


### PR DESCRIPTION
This label is misleading, as Kustomize is not actively managing any objects.