### PR TITLE
Fix "app.kubernetes.io/version" label in CI

### DIFF
--- a/deploy/ci/kustomization.yaml
+++ b/deploy/ci/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
-  app.kubernetes.io/version: 0.0.0-local
+  app.kubernetes.io/version: 0.0.0-ci
 resources:
   - ../dev
 patches:


### PR DESCRIPTION
Version was incorrectly stating local development version instead of CI.