### PR TITLE
Require secret to be created manually

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -70,6 +70,15 @@ jobs:
           version: v0.17.0
           config: deploy/kind/cluster-config.yaml
           wait: 600s
+      - run: |
+          kubectl create secret generic greenstar-google-app \
+            --save-config --output=yaml --dry-run=client \
+            --from-literal=GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID} \
+            --from-literal=GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET} \
+            | kubectl apply -f -
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       - run: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
       - run: kubectl wait --for=condition=available -n ingress-nginx deploy/ingress-nginx-controller
       - run: kubectl wait -n ingress-nginx job/ingress-nginx-admission-create --for=condition=complete

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ $ brew install skaffold                             # Kubernetes development too
 ```shell
 $ kind create cluster --config=deploy/kind/cluster-config.yaml --name=local
 $ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+$ cat > google-client-app.env <<EOF
+GOOGLE_CLIENT_ID=<your_google_oauth_client_id>
+GOOGLE_CLIENT_SECRET=<your_google_oauth_client_secret>
+EOF
+$ kubectl create secret generic greenstar-google-app \
+    --save-config \
+    --output=yaml \
+    --dry-run=client \
+    --from-env-file=google-client-app.env \
+    | kubectl apply -f -
 ```
 
 ### Running

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -40,17 +40,6 @@ profiles:
   - name: local-dev
     activation:
       - command: dev
-    deploy:
-      kubectl:
-        defaultNamespace: default
-        hooks:
-          before:
-            - host:
-                command:
-                  - sh
-                  - -cx
-                  - kubectl create secret generic greenstar-google-app -n default --save-config --output=yaml --dry-run=client --from-env-file=google-client-app.env | kubectl apply -f -
-                os: [ darwin, linux ]
     manifests:
       kustomize:
         paths:
@@ -89,17 +78,6 @@ profiles:
   - name: ci
     activation:
       - env: CI=true
-    deploy:
-      kubectl:
-        defaultNamespace: default
-        hooks:
-          before:
-            - host:
-                command:
-                  - sh
-                  - -cx
-                  - kubectl create secret generic greenstar-google-app -n default --save-config --output=yaml --dry-run=client --from-literal=GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID} --from-literal=GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET} | kubectl apply -f -
-                os: [ darwin, linux ]
     manifests:
       kustomize:
         paths:


### PR DESCRIPTION
This change requires that the "greenstar-google-app" secret be created manually during development and in CI, rather than automatically create it in the skaffold.yaml file.