### PR TITLE
Remove "moment" dependency from e2e

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,7 +14,6 @@
     "dotenv": "^16.0.3",
     "jsonwebtoken": "^9.0.0",
     "luxon": "^3.3.0",
-    "moment": "^2.29.4",
     "redis": "^4.6.5"
   }
 }


### PR DESCRIPTION
This library is considered stale and deprecated by the larger Node community, replaced by Luxon and others.

The original developers of "moment" stated that the main deficiency of it was its statefulness, which would be next to impossible to change without backwards-incompatible changes to it; and given that new better alternatives have risen, they moved it to maintenance mode.