### PR TITLE
Disable service links for Neo4j

### DIFF
--- a/deploy/base/neo4j.yaml
+++ b/deploy/base/neo4j.yaml
@@ -212,6 +212,7 @@ spec:
             - mountPath: /plugins
               name: plugins
               readOnly: false
+      enableServiceLinks: false
       serviceAccountName: greenstar-neo4j
       volumes:
         - name: backups


### PR DESCRIPTION
Kubernetes service links are environment variables added to pods to signal consuming services.

Unfortunately the naming conventions of these environment variables conflict with Neo4j configuration mechanisms and therefore need to be disabled.