### PR TITLE
Reduce default Neo4j CPU limits

### DIFF
--- a/deploy/base/neo4j.yaml
+++ b/deploy/base/neo4j.yaml
@@ -188,7 +188,7 @@ spec:
             timeoutSeconds: 5
           resources:
             limits:
-              cpu: 2000m
+              cpu: 500m
               memory: 1Gi
             requests:
               cpu: 500m


### PR DESCRIPTION
This change reduces the CPU limits for Neo4j from 2 CPUs to 0.5 CPU.

This is a reasonable default appropriate for development, and can be patched later by higher environments.