### PR TITLE
Rename "neo4j" port to "client" and revert #10

### DIFF
--- a/deploy/base/neo4j.yaml
+++ b/deploy/base/neo4j.yaml
@@ -188,7 +188,7 @@ spec:
             timeoutSeconds: 5
           resources:
             limits:
-              cpu: 500m
+              cpu: 2000m
               memory: 1Gi
             requests:
               cpu: 500m


### PR DESCRIPTION
Use the "client" name for the 7687 Neo4j-native port, instead of a generic "neo4j" name.

This PR eventually also reverted arikkfir/greenstar#10, which reduced the Neo4j resources. Turns out this can fail the e2e tests since Neo4j fails to pass the startup probe. Unfortunately, due to auto-merge being enabled, I did not have a chance to mention that in the commit message used for merging into `master`, hence I'm mentioning it here.