### PR TITLE
Rename "redis" port to "client"

### DIFF
--- a/deploy/base/redis.yaml
+++ b/deploy/base/redis.yaml
@@ -13,10 +13,10 @@ metadata:
   name: greenstar-redis
 spec:
   ports:
-    - name: redis
+    - name: client
       port: 6379
       protocol: TCP
-      targetPort: redis
+      targetPort: client
     - name: http
       port: 80
       protocol: TCP
@@ -63,7 +63,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
-              name: redis
+              name: client
             - containerPort: 8001
               name: http
           startupProbe:


### PR DESCRIPTION
This better signals the purpose of the port