### PR TITLE
Fix delivery environment deletion

### DIFF
--- a/.github/workflows/on-branch-deletion.yml
+++ b/.github/workflows/on-branch-deletion.yml
@@ -8,13 +8,27 @@ defaults:
 
 jobs:
 
+  get-deleted-branch:
+    name: "Get Branch"
+    if: github.ref_type == 'branch' && github.event.ref_type == 'branch'
+    runs-on: ubuntu-22.04
+    outputs:
+      name: ${{ steps.get-deleted-branch.outputs.name }}
+    steps:
+      - id: get-deleted-branch
+        run: |
+          REF="${{ github.event.ref }}"
+          BRANCH="${REF#refs/heads/}"
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
   delete-env:
     name: Delete environment
+    needs: get-deleted-branch
     if: github.ref_type == 'branch' && github.event.ref_type == 'branch'
     uses: arik-kfir/delivery/.github/workflows/delete-app-env.yml@main
     concurrency:
       group: deployment
       cancel-in-progress: false
     with:
-      environment: ${{ github.ref_name }}
+      environment: ${{ needs.get-deleted-branch.outputs.name }}
     secrets: inherit


### PR DESCRIPTION
When a branch is deleted, the corresponding environment should be deleted as well.

This change fixes a bug where the delivery environment corresponding to the head branch is deleted.