### PR TITLE
fix(deploy): restrict traffic to whitelisted IPs

### DIFF
--- a/deploy/cluster/kustomization.yaml
+++ b/deploy/cluster/kustomization.yaml
@@ -15,6 +15,11 @@ patches:
       - op: replace
         path: /spec/routes/0/match
         value: HostSNI(`redis.${flux_environment}.kfirs.com`)
+      - op: add
+        path: /spec/routes/0/middlewares
+        value:
+          - name: ip-whitelist-tcp
+            namespace: traefik
   - target:
       group: traefik.io
       version: v1alpha1
@@ -24,6 +29,11 @@ patches:
       - op: replace
         path: /spec/routes/0/match
         value: Host(`neo4j.${flux_environment}.kfirs.com`)
+      - op: add
+        path: /spec/routes/0/middlewares
+        value:
+          - name: ip-whitelist
+            namespace: traefik
   - target:
       group: traefik.io
       version: v1alpha1
@@ -33,6 +43,11 @@ patches:
       - op: replace
         path: /spec/routes/0/match
         value: HostSNI(`neo4j.${flux_environment}.kfirs.com`)
+      - op: add
+        path: /spec/routes/0/middlewares
+        value:
+          - name: ip-whitelist-tcp
+            namespace: traefik
   - target:
       group: traefik.io
       version: v1alpha1
@@ -42,6 +57,11 @@ patches:
       - op: replace
         path: /spec/routes/0/match
         value: Host(`api.${flux_environment}.kfirs.com`)
+      - op: add
+        path: /spec/routes/0/middlewares
+        value:
+          - name: ip-whitelist
+            namespace: traefik
   - target:
       group: traefik.io
       version: v1alpha1
@@ -51,6 +71,11 @@ patches:
       - op: replace
         path: /spec/routes/0/match
         value: HostRegexp(`{tenant:[a-zA-Z][a-zA-Z0-9_-]*}.${flux_environment}.kfirs.com`)
+      - op: add
+        path: /spec/routes/0/middlewares
+        value:
+          - name: ip-whitelist
+            namespace: traefik
   - target:
       group: apps
       version: v1


### PR DESCRIPTION
This change patches IngressRoute and IngressRouteTCP objects to use the "ip-whitelist" or "ip-whitelist-tcp" middleware, which will ensure that Traefik restricts traffic accordingly.