### PR TITLE
fix(backend): provide missing Descope secrets when running in cluster

### DIFF
--- a/deploy/base/app/backend.yaml
+++ b/deploy/base/app/backend.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: greenstar-backend@arikkfir.iam.gserviceaccount.com
   labels:
     app.kubernetes.io/component: backend
   name: backend

--- a/deploy/base/app/frontend.yaml
+++ b/deploy/base/app/frontend.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: greenstar-frontend@arikkfir.iam.gserviceaccount.com
   labels:
     app.kubernetes.io/component: frontend
   name: frontend

--- a/deploy/cluster/gcp-iam.yaml
+++ b/deploy/cluster/gcp-iam.yaml
@@ -1,0 +1,74 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: greenstar-backend
+spec:
+  displayName: GreenSTAR Backend
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: greenstar-backend-ksa-link
+spec:
+  member: serviceAccount:arikkfir.svc.id.goog[${flux_environment}/greenstar-backend]
+  role: roles/iam.workloadIdentityUser
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: greenstar-backend
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: greenstar-backend-descope-project-secret-viewer
+spec:
+  memberFrom:
+    serviceAccountRef:
+      name: greenstar-backend
+  role: roles/secretmanager.viewer
+  resourceRef:
+    apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    kind: SecretManagerSecret
+    external: projects/8909046976/secrets/greenstar-descope-project-id
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: greenstar-backend-descope-project-secret-accessor
+spec:
+  memberFrom:
+    serviceAccountRef:
+      name: greenstar-backend
+  role: roles/secretmanager.secretAccessor
+  resourceRef:
+    apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    kind: SecretManagerSecret
+    external: projects/8909046976/secrets/greenstar-descope-project-id
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: greenstar-backend-descope-key-secret-viewer
+spec:
+  memberFrom:
+    serviceAccountRef:
+      name: greenstar-backend
+  role: roles/secretmanager.viewer
+  resourceRef:
+    apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    kind: SecretManagerSecret
+    external: projects/8909046976/secrets/greenstar-descope-management-key
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: greenstar-backend-descope-key-secret-accessor
+spec:
+  memberFrom:
+    serviceAccountRef:
+      name: greenstar-backend
+  role: roles/secretmanager.secretAccessor
+  resourceRef:
+    apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    kind: SecretManagerSecret
+    external: projects/8909046976/secrets/greenstar-descope-management-key

--- a/deploy/cluster/kustomization.yaml
+++ b/deploy/cluster/kustomization.yaml
@@ -20,6 +20,11 @@ patches:
           - secretRef:
               name: greenstar-descope
               optional: false
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: HTTP_CORS_ALLOWED_ORIGINS
+          value: "https://*.${flux_environment}.kfirs.com"
   - target:
       group: traefik.io
       version: v1alpha1

--- a/deploy/cluster/kustomization.yaml
+++ b/deploy/cluster/kustomization.yaml
@@ -24,7 +24,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: HTTP_CORS_ALLOWED_ORIGINS
-          value: "https://*.${flux_environment}.kfirs.com"
+          value: "https://*.${flux_environment}.greenstar.kfirs.com"
   - target:
       group: traefik.io
       version: v1alpha1

--- a/deploy/cluster/kustomization.yaml
+++ b/deploy/cluster/kustomization.yaml
@@ -5,7 +5,21 @@ resources:
   - ../base
   - certificate.yaml
   - dnsrecord.yaml
+  - gcp-iam.yaml
+  - secrets.yaml
 patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      labelSelector: app.kubernetes.io/component=backend
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/envFrom
+        value:
+          - secretRef:
+              name: greenstar-descope
+              optional: false
   - target:
       group: traefik.io
       version: v1alpha1

--- a/deploy/cluster/secrets.yaml
+++ b/deploy/cluster/secrets.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: greenstar-gcpsm
+spec:
+  provider:
+    gcpsm:
+      projectID: arikkfir
+      auth:
+        workloadIdentity:
+          clusterLocation: me-west1-a
+          clusterName: main
+          serviceAccountRef:
+            name: greenstar-backend # TODO: use a dedicated SA for secrets instead of the backend SA
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: greenstar-descope
+spec:
+  refreshInterval: 30m
+  secretStoreRef:
+    kind: SecretStore
+    name: greenstar-gcpsm
+  data:
+    - secretKey: AUTH_DESCOPE_PROJECT_ID
+      remoteRef:
+        key: greenstar-descope-project-id
+    - secretKey: AUTH_DESCOPE_MANAGEMENT_KEY
+      remoteRef:
+        key: greenstar-descope-management-key


### PR DESCRIPTION
This change modifies the cluster deployment manifests to mirror Descope GCP secrets into the cluster, and providing them to the backend deployment.