### PR TITLE
fix(backend): provide missing HTTP CORS allowed origins

### DIFF
--- a/deploy/cluster/kustomization.yaml
+++ b/deploy/cluster/kustomization.yaml
@@ -7,6 +7,17 @@ resources:
   - dnsrecord.yaml
 patches:
   - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      labelSelector: app.kubernetes.io/component=backend
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: HTTP_CORS_ALLOWED_ORIGINS
+          value: "https://*.${flux_environment}.greenstar.kfirs.com"
+  - target:
       group: traefik.io
       version: v1alpha1
       kind: IngressRouteTCP


### PR DESCRIPTION
This configuration is required to ensure that calls to the backend are only allowed from the application domains.