### PR TITLE
fix(frontend): fail frontend if tenant cannot be extracted from domain

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -48,7 +48,7 @@ const growthBook = new GrowthBook({
 const rootElt = document.getElementById('root')!;
 const root = createRoot(rootElt);
 const tenant = getSubdomain();
-if (tenant == null) {
+if (tenant == null || tenant == "") {
     root.render(
         <StrictMode>
             <div>Tenant could not be found.</div>


### PR DESCRIPTION
Do not load the application if it fails inferring the tenant from the URL subdomain.