### PR TITLE
chore(ci): remove redundant Docker image tag

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -40,7 +40,6 @@ jobs:
             type=sha,prefix=,suffix=,format=short
             type=sha,prefix=,suffix=,format=long
             type=ref,event=branch
-            type=ref,event=pr
       - uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
No need to tag container image with PR info - we're building branches only.