### PR TITLE
fix(frontend): adjust NGINX for HTML5 routing

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -27,9 +27,19 @@ http {
         listen  [::]:80;
         server_name  localhost;
 
+        root   /workspace;
+        index  index.html;
+
         location / {
-            root   /workspace;
-            index  index.html index.htm;
+          try_files $uri $uri/ @rewrites;
+        }
+        location @rewrites {
+          rewrite ^(.+)$ /index.html last;
+        }
+        location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
+          expires max;
+          add_header Pragma public;
+          add_header Cache-Control "public, must-revalidate, proxy-revalidate";
         }
     }
 }


### PR DESCRIPTION
This change ensures that NGINX serves the "index.html" file on missing routes.