### PR TITLE
fix(ci): Fix ref and SHA inference for push-triggered builds

### DIFF
--- a/.github/workflows/pr_deploy.yml
+++ b/.github/workflows/pr_deploy.yml
@@ -45,8 +45,8 @@ jobs:
         name: Get ref from push
         if: github.event_name == 'push'
         run: |
-          echo "ref=${{ github.ref_name }} >> "$GITHUB_OUTPUT"
-          echo "sha=${{ github.sha }} >> "$GITHUB_OUTPUT"
+          echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
   backend-format:
     needs: get-ref


### PR DESCRIPTION
Fix a workflow bug causing an incorrect inference of the branch & SHA when triggered by a push event.