### PR TITLE
fix(e2e): ignore TLS certificate errors since we're using LE staging

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
         actionTimeout: 0,
         /* Base URL to use in actions like `await page.goto('/')`. */
         // baseURL: 'http://127.0.0.1:3000',
+        ignoreHTTPSErrors: true,
         trace: 'on',
     },
     projects: [


### PR DESCRIPTION
This is required since we're using Let's Encrypt Staging server for non-main environments.