### PR TITLE
fix(ci): Fix PR comment duplication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -267,13 +267,13 @@ jobs:
         run: curl -i https://acme.app.greenstar.test/
 
       - name: Find PR Comment
-        if: github.event_name == 'pull_request' && (success() || steps.test.outcome == 'success' || steps.test.outcome == 'failure')
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v3
         id: pr_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           token: ${{ github.token }}
-          body-includes: '[End-to-end tests report]'
+          body-includes: 'End-to-end tests report'
 
       - name: Create/update PR comment to In Progress
         if: github.event_name == 'pull_request'
@@ -329,6 +329,15 @@ jobs:
             ${{ steps.test.outcome == 'success' && ':white_check_mark:' || ':x:' }} [End-to-end tests report][1]
             
             [1]: https://static.kfirs.com/github/${{ github.repository }}/${{ github.event_name == 'push' && 'commit' || 'pr' }}/${{ github.event_name == 'push' && github.sha || github.ref_name }}/e2e/monocart-report/
+
+      - name: Find PR Comment
+        if: github.event_name == 'pull_request' && (success() || steps.test.outcome == 'success' || steps.test.outcome == 'failure')
+        uses: peter-evans/find-comment@v3
+        id: pr_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ github.token }}
+          body-includes: 'End-to-end tests report'
 
       - name: Create/update PR comment with result
         if: github.event_name == 'pull_request' && (success() || steps.test.outcome == 'success' || steps.test.outcome == 'failure')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -269,11 +269,11 @@ jobs:
       - name: Find PR Comment
         if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v3
-        id: pr_comment
+        id: pr_comment_1
         with:
           issue-number: ${{ github.event.pull_request.number }}
           token: ${{ github.token }}
-          body-includes: 'End-to-end tests report'
+          body-includes: '[End-to-end tests report]'
 
       - name: Create/update PR comment to In Progress
         if: github.event_name == 'pull_request'
@@ -281,7 +281,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           token: ${{ github.token }}
-          comment-id: ${{ steps.pr_comment.outputs.comment-id }}
+          comment-id: ${{ steps.pr_comment_1.outputs.comment-id }}
           edit-mode: replace
           body: |
             ${{ ':hourglass_flowing_sand:' }} [End-to-end tests report][1]
@@ -333,11 +333,11 @@ jobs:
       - name: Find PR Comment
         if: github.event_name == 'pull_request' && (success() || steps.test.outcome == 'success' || steps.test.outcome == 'failure')
         uses: peter-evans/find-comment@v3
-        id: pr_comment
+        id: pr_comment_2
         with:
           issue-number: ${{ github.event.pull_request.number }}
           token: ${{ github.token }}
-          body-includes: 'End-to-end tests report'
+          body-includes: '[End-to-end tests report]'
 
       - name: Create/update PR comment with result
         if: github.event_name == 'pull_request' && (success() || steps.test.outcome == 'success' || steps.test.outcome == 'failure')
@@ -345,7 +345,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           token: ${{ github.token }}
-          comment-id: ${{ steps.pr_comment.outputs.comment-id }}
+          comment-id: ${{ steps.pr_comment_2.outputs.comment-id }}
           edit-mode: replace
           body: |
             ${{ steps.test.outcome == 'success' && ':white_check_mark:' || ':x:' }} [End-to-end tests report][1]


### PR DESCRIPTION
Current workflow when running for PRs duplicates the comment with the link to test results, instead of updating it.