### PR TITLE
chore(build): Deploy observability in local dev mode

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -289,6 +289,7 @@ tasks:
   dev:
     deps: [ generate-rest-server, setup-cluster ]
     cmds:
+      - task: setup-observability
       - task: generate-helm-values
       - skaffold dev --tail=false --toot=true
 


### PR DESCRIPTION
This change deploys the observability stack when running locally.