### PR TITLE
fix(rates): Fail if transaction cannot be created

### DIFF
--- a/backend/internal/migration/fetch_historical_rates.go
+++ b/backend/internal/migration/fetch_historical_rates.go
@@ -121,6 +121,9 @@ func (m *exchangeRatesManagerImpl) PopulateHistoricalRates(ctx context.Context, 
 		AccessMode:     pgx.ReadWrite,
 		DeferrableMode: pgx.NotDeferrable,
 	})
+	if err != nil {
+		return fmt.Errorf("failed creating transaction: %w", err)
+	}
 	defer tx.Rollback(ctx)
 
 	// Delete all rates first, to start from scratch


### PR DESCRIPTION
This change adds a missing check for error when creating a transaction.