### PR TITLE
chore(ide): Remove redundant module

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/fetch-exchange-rates.iml" filepath="$PROJECT_DIR$/fetch-exchange-rates.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/greenstar.iml" filepath="$PROJECT_DIR$/.idea/greenstar.iml" />
     </modules>
   </component>


### PR DESCRIPTION
There were two modules defined in the JetBrains IDE project, causing duplications and a few minor issues.