### PR TITLE
chore(ide): Ignore smithy code completion

### DIFF
--- a/.idea/go.imports.xml
+++ b/.idea/go.imports.xml
@@ -3,6 +3,7 @@
   <component name="GoImports">
     <option name="excludedPackages">
       <array>
+        <option value="github.com/aws/smithy-go/testing" />
         <option value="github.com/docker/distribution/context" />
         <option value="github.com/pkg/errors" />
         <option value="golang.org/x/exp/slices" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/fetch-exchange-rates.iml" filepath="$PROJECT_DIR$/fetch-exchange-rates.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/greenstar.iml" filepath="$PROJECT_DIR$/.idea/greenstar.iml" />
     </modules>
   </component>


### PR DESCRIPTION
Ignore the AWS `smithy` package for code completions in JetBrains IDEs (it's rarely the one you need).