### PR TITLE
feat(backend): Allow running the application without the init job

### DIFF
--- a/deploy/chart/templates/init-job.tpl.yaml
+++ b/deploy/chart/templates/init-job.tpl.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.initJob.enabled }}
 {{- $prefix := include "greenstar.prefix" . -}}
 {{- $componentName := "init-job" -}}
 {{- $serviceAccountName := printf "%s-%s" $prefix $componentName -}}
@@ -181,3 +182,4 @@ spec:
         - name: gcp-oidc
           configMap:
             name: gcp-oidc
+{{- end }}

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -151,6 +151,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "extraArgs": {
           "$ref": "#/$defs/extraArgs"
         },

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -71,6 +71,7 @@ frontend:
   volumes: [ ]
 
 initJob:
+  enabled: true
   extraArgs: [ ]
   extraEnv: [ ]
   image:


### PR DESCRIPTION
This change makes the "init-job" component optional, allowing local development of the init-job by running it manually on the workstation instead of in the local cluster.