### PR TITLE
fix(backend): Tracer  usage failed when OTEL SDK is disabled

### DIFF
--- a/deploy/chart/templates/init-job.tpl.yaml
+++ b/deploy/chart/templates/init-job.tpl.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.initJob.enabled }}
 {{- $prefix := include "greenstar.prefix" . -}}
 {{- $componentName := "init-job" -}}
 {{- $serviceAccountName := printf "%s-%s" $prefix $componentName -}}
@@ -181,3 +182,4 @@ spec:
         - name: gcp-oidc
           configMap:
             name: gcp-oidc
+{{- end }}

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -151,6 +151,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "extraArgs": {
           "$ref": "#/$defs/extraArgs"
         },

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -71,6 +71,7 @@ frontend:
   volumes: [ ]
 
 initJob:
+  enabled: true
   extraArgs: [ ]
   extraEnv: [ ]
   image:


### PR DESCRIPTION
This change fixes the panic that happens when the OTEL SDK is disabled and code is using the `Tracer` field.