### PR TITLE
feat(frontend): Allow disabling liveness, readiness & startup probes

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -162,7 +162,7 @@ func (e *Action) newServer(ctx context.Context, logSuccessfulRequests bool, desc
 
 func main() {
 
-	defaultMaxAge, err := time.ParseDuration("60s")
+	defaultMaxAge, err := time.ParseDuration("5s")
 	if err != nil {
 		panic(err)
 	}

--- a/deploy/chart/templates/frontend.tpl.yaml
+++ b/deploy/chart/templates/frontend.tpl.yaml
@@ -82,6 +82,7 @@ spec:
             requests:
               cpu: {{ .Values.frontend.resources.requests.cpu | default "50m" | quote }}
               memory: {{ .Values.frontend.resources.requests.memory | default "32Mi" | quote }}
+          {{- if .Values.frontend.livenessProbe }}
           livenessProbe:
             httpGet:
               port: http
@@ -90,6 +91,8 @@ spec:
             periodSeconds: 5
             terminationGracePeriodSeconds: 30
             timeoutSeconds: 3
+          {{- end }}
+          {{- if .Values.frontend.readinessProbe }}
           readinessProbe:
             httpGet:
               port: http
@@ -97,6 +100,8 @@ spec:
             failureThreshold: 3
             periodSeconds: 1
             timeoutSeconds: 1
+          {{- end }}
+          {{- if .Values.frontend.startupProbe }}
           startupProbe:
             httpGet:
               port: http
@@ -107,6 +112,7 @@ spec:
             failureThreshold: 10
             timeoutSeconds: 1
             terminationGracePeriodSeconds: 60
+          {{- end }}
           {{- if not (empty .Values.frontend.volumeMounts) }}
           volumeMounts:
             {{- toYaml .Values.frontend.volumeMounts | nindent 12 }}

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -270,6 +270,15 @@
         },
         "volumes": {
           "$ref": "#/$defs/volumesConfiguration"
+        },
+        "readinessProbe": {
+          "type": "boolean"
+        },
+        "livenessProbe": {
+          "type": "boolean"
+        },
+        "startupProbe": {
+          "type": "boolean"
         }
       }
     },

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -69,6 +69,9 @@ frontend:
       memory: ""
   volumeMounts: [ ]
   volumes: [ ]
+  livenessProbe: true
+  readinessProbe: true
+  startupProbe: true
 
 initJob:
   enabled: true

--- a/deploy/local/chart-local-values.yaml
+++ b/deploy/local/chart-local-values.yaml
@@ -64,6 +64,9 @@ frontend:
     requests:
       cpu: 500m
       memory: 1Gi
+  readinessProbe: false
+  livenessProbe: false
+  startupProbe: false
 
 initJob:
   extraEnv:


### PR DESCRIPTION
This change adds support for disabling the pod liveness, readiness & startup probes of the Frontend pod(s), which is necessary during development as the frontend server will be the Vite server rather than the NGINX server used in production.

Thus, instead of implementing health checks in the Vite server (using Express app) this makes it easier by simply disabling these checks when developing locally.