### PR TITLE
feat(build): Remove observability dependency from "dev" build task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -319,7 +319,6 @@ tasks:
   dev:
     deps: [ generate-rest-server, setup-cluster ]
     cmds:
-      - task: setup-observability
       - task: generate-helm-values
       - skaffold dev --tail=false --toot=true
 


### PR DESCRIPTION
This allows running locally without observability, provided one has added "OTEL_SDK_DISABLED" environment variables to the "backend", "initJob" and "exchangeRatesCronJob" workloads with the value "false".

One can modify "hack/greenstar-values.yaml" to do so:

```yaml
...
backend:
  extraEnv:
    - name: OTEL_SDK_DISABLED
      value: "true"
exchangeRatesCronJob:
  extraEnv:
    - name: OTEL_SDK_DISABLED
      value: "true"
initJob:
  extraEnv:
    - name: OTEL_SDK_DISABLED
      value: "true"
```