### PR TITLE
fix(backend): Init job does not generate sample data

### DIFF
--- a/backend/cmd/jobs/init/main.go
+++ b/backend/cmd/jobs/init/main.go
@@ -30,7 +30,7 @@ import (
 type Action struct {
 	Descope                       auth.DescopeConfig
 	CurrencyAPIKey                string `required:"true" env:"CURRENCY_API_KEY"`
-	GenerateSampleData            bool   `flag:"true"`
+	DisableSampleDataGeneration            bool   `flag:"true"`
 	Namespace                     string `flag:"true" env:"POD_NAMESPACE"`
 	ExchangeRatesCronJobName      string `flag:"true" env:"EXCHANGE_RATES_CRONJOB_NAME"`
 	HistoricalExchangeRatesPeriod string `flag:"true"`
@@ -111,7 +111,7 @@ func (e *Action) Run(ctx context.Context) error {
 	}
 
 	// Generate sample data
-	if e.GenerateSampleData {
+	if !e.DisableSampleDataGeneration {
 		th := appServer.TenantsHandler
 		txh := appServer.TransactionsHandler
 		ah := accountsHandler
@@ -121,6 +121,8 @@ func (e *Action) Run(ctx context.Context) error {
 		if err := sample.Generate(ctx, appServer.Descope, accessKey, pgPool, th, tenantID, tenantDisplayName, txh, ah); err != nil {
 			return err
 		}
+	} else {
+		slog.Default().WarnContext(ctx, "Sample data generation has been DISABLED")
 	}
 
 	// Ensure fill-in any missing rates


### PR DESCRIPTION
This is caused by incorrect assumption for the default value of the (now deleted) "GENERATE_SAMPLE_DATA" flag; boolean values ALWAYS have a default value of "false" (because in the CLI they are just specified as `--my-flag` without any value...).

To fix the issue, this change modifies the flag to be in the negative - by renaming it from `--generate-sample-data` to
`--disable-sample-data-generation`.