### PR TITLE
fix(build): Skaffold deployment hooks fail

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -49,8 +49,12 @@ deploy:
             command:
               - bash
               - -c
-              - yq -e '[.frontend.extraEnv[] | select(.name == "VITE_DESCOPE_PROJECT_ID")] | length == 1' ./hack/greenstar-values.yaml || yq -i ".frontend.extraEnv += [{name:\"VITE_DESCOPE_PROJECT_ID\",value:\"${DESCOPE_PROJECT_ID}\"}]" ./hack/greenstar-values.yaml
-              - yq -e '[.frontend.extraEnv[] | select(.name == "VITE_LOCATION_IQ_ACCESS_TOKEN")] | length == 1' ./hack/greenstar-values.yaml || yq -i ".frontend.extraEnv += [{name:\"VITE_LOCATION_IQ_ACCESS_TOKEN\",value:\"${LOCATION_IQ_ACCESS_TOKEN}\"}]" ./hack/greenstar-values.yaml
+              - yq -e '[.frontend.extraEnv[] | select(.name == "VITE_DESCOPE_PROJECT_ID")] | length == 1' ./hack/greenstar-values.yaml || yq -i ".frontend.extraEnv += [{\"name\":\"VITE_DESCOPE_PROJECT_ID\",\"value\":\"${DESCOPE_PROJECT_ID}\"}]" ./hack/greenstar-values.yaml
+        - host:
+            command:
+              - bash
+              - -c
+              - yq -e '[.frontend.extraEnv[] | select(.name == "VITE_LOCATION_IQ_ACCESS_TOKEN")] | length == 1' ./hack/greenstar-values.yaml || yq -i ".frontend.extraEnv += [{\"name\":\"VITE_LOCATION_IQ_ACCESS_TOKEN\",\"value\":\"${LOCATION_IQ_ACCESS_TOKEN}\"}]" ./hack/greenstar-values.yaml
     releases:
       - name: '{{default (list "greenstar" (cmd "whoami") | join "-") .HELM_RELEASE_NAME}}'
         chartPath: ./deploy/chart


### PR DESCRIPTION
This change fixes the Skaffold pre-deploy hooks by adding the missing quotes and also performing the two patches in one command.