### PR TITLE
refactor(build): Support "extraEnv" composition from multiple files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -245,7 +245,6 @@ jobs:
       - name: Generate Helm values file
         run: |
           task -v generate-helm-values
-          yq -i ".frontend.extraEnv += [{\"name\": \"OTEL_SDK_DISABLED\",\"value\": \"true\"}]" ./hack/greenstar-values.yaml
 
       - name: Authenticate to GHCR
         uses: docker/login-action@v3

--- a/deploy/chart/templates/backend.tpl.yaml
+++ b/deploy/chart/templates/backend.tpl.yaml
@@ -109,8 +109,9 @@ spec:
               value: "disable"
             - name: HTTP_ALLOWED_ORIGINS
               value: "https://signup.{{ .Values.ingress.domain }},https://app.{{ .Values.ingress.domain }},https://*.app.{{ .Values.ingress.domain }}"
-            {{- if not (empty .Values.backend.extraEnv) }}
-            {{- toYaml .Values.backend.extraEnv | nindent 12 }}
+            {{- range $key, $value := .Values.backend.extraEnv }}
+            - name: {{ $key | quote }}
+              {{ toYaml $value | nindent 14 }}
             {{- end }}
           name: {{ $componentName | quote }}
           ports:

--- a/deploy/chart/templates/exchange-rates-cronjob.tpl.yaml
+++ b/deploy/chart/templates/exchange-rates-cronjob.tpl.yaml
@@ -89,9 +89,10 @@ spec:
                   value: "disable"
                 - name: CURRENCY_API_KEY
                   value: {{ .Values.currencyAPI.key | quote }}
-              {{- if not (empty .Values.exchangeRatesCronJob.extraEnv) }}
-                {{- toYaml .Values.exchangeRatesCronJob.extraEnv | nindent 16 }}
-              {{- end }}
+                {{- range $key, $value := .Values.exchangeRatesCronJob.extraEnv }}
+                - name: {{ $key | quote }}
+                  {{ toYaml $value | nindent 18 }}
+                {{- end }}
               name: {{ $componentName | quote }}
               ports:
                 - containerPort: 8000

--- a/deploy/chart/templates/frontend.tpl.yaml
+++ b/deploy/chart/templates/frontend.tpl.yaml
@@ -67,10 +67,13 @@ spec:
           args:
             {{- toYaml .Values.frontend.extraArgs | nindent 12 }}
           {{- end }}
-          {{- if not (empty .Values.frontend.extraEnv) }}
           env:
-            {{- toYaml .Values.frontend.extraEnv | nindent 12 }}
-          {{- end }}
+            - name: DUMMY
+              value: DUMB
+            {{- range $key, $value := .Values.frontend.extraEnv }}
+            - name: {{ $key | quote }}
+              {{ toYaml $value | nindent 14 }}
+            {{- end }}
           name: {{ $componentName | quote }}
           ports:
             - containerPort: 3000

--- a/deploy/chart/templates/init-job.tpl.yaml
+++ b/deploy/chart/templates/init-job.tpl.yaml
@@ -143,8 +143,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if not (empty .Values.initJob.extraEnv) }}
-            {{- toYaml .Values.initJob.extraEnv | nindent 12 }}
+            {{- range $key, $value := .Values.initJob.extraEnv }}
+            - name: {{ $key | quote }}
+              {{ toYaml $value | nindent 14 }}
             {{- end }}
           name: {{ $componentName | quote }}
           ports:

--- a/deploy/chart/templates/postgres.tpl.yaml
+++ b/deploy/chart/templates/postgres.tpl.yaml
@@ -126,8 +126,9 @@ spec:
                   name: {{ $secretName | quote }}
                   key: init-pwd
                   optional: false
-            {{- if not (empty .Values.postgres.extraEnv) }}
-            {{- toYaml .Values.postgres.extraEnv | nindent 12 }}
+            {{- range $key, $value := .Values.postgres.extraEnv }}
+            - name: {{ $key | quote }}
+              {{ toYaml $value | nindent 14 }}
             {{- end }}
           name: {{ $componentName | quote }}
           ports:

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -328,10 +328,8 @@
       }
     },
     "extraEnv": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
+      "type": "object",
+      "additionalProperties": true
     },
     "image": {
       "type": "object",
@@ -342,8 +340,7 @@
           "minLength": 1
         },
         "tag": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "pullPolicy": {
           "type": "string",

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -28,7 +28,7 @@ observability:
 
 backend:
   extraArgs: [ ]
-  extraEnv: [ ]
+  extraEnv: {}
   image:
     repository: ghcr.io/arikkfir/greenstar/backend
     tag: ""
@@ -51,7 +51,7 @@ backend:
 
 frontend:
   extraArgs: [ ]
-  extraEnv: [ ]
+  extraEnv: {}
   image:
     repository: ghcr.io/arikkfir/greenstar/frontend
     tag: ""
@@ -76,7 +76,7 @@ frontend:
 initJob:
   enabled: true
   extraArgs: [ ]
-  extraEnv: [ ]
+  extraEnv: {}
   image:
     repository: ghcr.io/arikkfir/greenstar/init-job
     tag: ""
@@ -97,7 +97,7 @@ initJob:
 
 exchangeRatesCronJob:
   extraArgs: [ ]
-  extraEnv: [ ]
+  extraEnv: {}
   image:
     repository: ghcr.io/arikkfir/greenstar/exchange-rates-job
     tag: ""
@@ -122,7 +122,7 @@ postgres:
   backendPassword: ""
 
   extraArgs: [ ]
-  extraEnv: [ ]
+  extraEnv: {}
   extraUsers: { }
 
   # Set init job's password (defaults to random alphanumeric passwords)

--- a/deploy/local/chart-ci-values.yaml
+++ b/deploy/local/chart-ci-values.yaml
@@ -7,18 +7,8 @@ ingress:
 
 backend:
   extraEnv:
-    - name: OTEL_METRICS_EXPORTER
-      value: "prometheus"
-    - name: OTEL_LOGS_EXPORTER
-      value: "none"
-    - name: OTEL_EXPORTER_PROMETHEUS_HOST
-      value: "0.0.0.0"
-    - name: OTEL_EXPORTER_PROMETHEUS_PORT
-      value: "8000"
-    - name: OTEL_TRACES_EXPORTER
-      value: "otlp"
-    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-      value: "http://jaeger-all-in-one.observability.svc.cluster.local:4318/v1/traces"
+    OTEL_SDK_DISABLED:
+      value: "true"
   ingress:
     enabled: true
     parentRef:
@@ -30,18 +20,8 @@ backend:
 
 exchangeRatesCronJob:
   extraEnv:
-    - name: OTEL_METRICS_EXPORTER
-      value: "prometheus"
-    - name: OTEL_LOGS_EXPORTER
-      value: "none"
-    - name: OTEL_EXPORTER_PROMETHEUS_HOST
-      value: "0.0.0.0"
-    - name: OTEL_EXPORTER_PROMETHEUS_PORT
-      value: "8000"
-    - name: OTEL_TRACES_EXPORTER
-      value: "otlp"
-    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-      value: "http://jaeger-all-in-one.observability.svc.cluster.local:4318/v1/traces"
+    OTEL_SDK_DISABLED:
+      value: "true"
 
 frontend:
   ingress:
@@ -55,20 +35,8 @@ frontend:
 
 initJob:
   extraEnv:
-    - name: GENERATE_SAMPLE_DATA
-      value: "T"
-    - name: OTEL_METRICS_EXPORTER
-      value: "prometheus"
-    - name: OTEL_LOGS_EXPORTER
-      value: "none"
-    - name: OTEL_EXPORTER_PROMETHEUS_HOST
-      value: "0.0.0.0" # we should modify jobs to PUSH metrics instead of using pull (when OTEL supports it)
-    - name: OTEL_EXPORTER_PROMETHEUS_PORT
-      value: "8000"
-    - name: OTEL_TRACES_EXPORTER
-      value: "otlp"
-    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-      value: "http://jaeger-all-in-one.observability.svc.cluster.local:4318/v1/traces"
+    OTEL_SDK_DISABLED:
+      value: "true"
 
 postgres:
   backendPassword: "local"

--- a/deploy/local/chart-local-values.yaml
+++ b/deploy/local/chart-local-values.yaml
@@ -8,17 +8,17 @@ ingress:
 
 backend:
   extraEnv:
-    - name: OTEL_METRICS_EXPORTER
+    OTEL_METRICS_EXPORTER:
       value: "prometheus"
-    - name: OTEL_LOGS_EXPORTER
+    OTEL_LOGS_EXPORTER:
       value: "none"
-    - name: OTEL_EXPORTER_PROMETHEUS_HOST
-      value: "0.0.0.0"
-    - name: OTEL_EXPORTER_PROMETHEUS_PORT
+    OTEL_EXPORTER_PROMETHEUS_HOST:
+      value: "0.0.0.0" # we should modify jobs to PUSH metrics instead of using pull (when OTEL supports it)
+    OTEL_EXPORTER_PROMETHEUS_PORT:
       value: "8000"
-    - name: OTEL_TRACES_EXPORTER
+    OTEL_TRACES_EXPORTER:
       value: "otlp"
-    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:
       value: "http://jaeger-all-in-one.observability.svc.cluster.local:4318/v1/traces"
   ingress:
     enabled: true
@@ -31,23 +31,23 @@ backend:
 
 exchangeRatesCronJob:
   extraEnv:
-    - name: OTEL_METRICS_EXPORTER
+    OTEL_METRICS_EXPORTER:
       value: "prometheus"
-    - name: OTEL_LOGS_EXPORTER
+    OTEL_LOGS_EXPORTER:
       value: "none"
-    - name: OTEL_EXPORTER_PROMETHEUS_HOST
-      value: "0.0.0.0"
-    - name: OTEL_EXPORTER_PROMETHEUS_PORT
+    OTEL_EXPORTER_PROMETHEUS_HOST:
+      value: "0.0.0.0" # we should modify jobs to PUSH metrics instead of using pull (when OTEL supports it)
+    OTEL_EXPORTER_PROMETHEUS_PORT:
       value: "8000"
-    - name: OTEL_TRACES_EXPORTER
+    OTEL_TRACES_EXPORTER:
       value: "otlp"
-    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:
       value: "http://jaeger-all-in-one.observability.svc.cluster.local:4318/v1/traces"
 
 frontend:
   extraArgs: [ "--", "--logLevel=info", "--port=3000", "--host=0.0.0.0" ]
   extraEnv:
-    - name: "VITE_SLOW_REQUESTS"
+    VITE_SLOW_REQUESTS:
       value: "F"
   ingress:
     enabled: true
@@ -70,19 +70,17 @@ frontend:
 
 initJob:
   extraEnv:
-    - name: GENERATE_SAMPLE_DATA
-      value: "T"
-    - name: OTEL_METRICS_EXPORTER
+    OTEL_METRICS_EXPORTER:
       value: "prometheus"
-    - name: OTEL_LOGS_EXPORTER
+    OTEL_LOGS_EXPORTER:
       value: "none"
-    - name: OTEL_EXPORTER_PROMETHEUS_HOST
+    OTEL_EXPORTER_PROMETHEUS_HOST:
       value: "0.0.0.0" # we should modify jobs to PUSH metrics instead of using pull (when OTEL supports it)
-    - name: OTEL_EXPORTER_PROMETHEUS_PORT
+    OTEL_EXPORTER_PROMETHEUS_PORT:
       value: "8000"
-    - name: OTEL_TRACES_EXPORTER
+    OTEL_TRACES_EXPORTER:
       value: "otlp"
-    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:
       value: "http://jaeger-all-in-one.observability.svc.cluster.local:4318/v1/traces"
 
 postgres:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -47,10 +47,12 @@ deploy:
       before:
         - host:
             command:
-              - bash
-              - -c
-              - yq -e '[.frontend.extraEnv[] | select(.name == "VITE_DESCOPE_PROJECT_ID")] | length == 1' ./hack/greenstar-values.yaml || yq -i ".frontend.extraEnv += [{name:\"VITE_DESCOPE_PROJECT_ID\",value:\"${DESCOPE_PROJECT_ID}\"}]" ./hack/greenstar-values.yaml
-              - yq -e '[.frontend.extraEnv[] | select(.name == "VITE_LOCATION_IQ_ACCESS_TOKEN")] | length == 1' ./hack/greenstar-values.yaml || yq -i ".frontend.extraEnv += [{name:\"VITE_LOCATION_IQ_ACCESS_TOKEN\",value:\"${LOCATION_IQ_ACCESS_TOKEN}\"}]" ./hack/greenstar-values.yaml
+              - yq
+              - -e
+              - |
+                .frontend.extraEnv.VITE_DESCOPE_PROJECT_ID = {"value":"{{.DESCOPE_PROJECT_ID}}"} |
+                .frontend.extraEnv.VITE_LOCATION_IQ_ACCESS_TOKEN = {"value":"{{.LOCATION_IQ_ACCESS_TOKEN}}"}
+              - ./hack/greenstar-values.yaml
     releases:
       - name: '{{default (list "greenstar" (cmd "whoami") | join "-") .HELM_RELEASE_NAME}}'
         chartPath: ./deploy/chart


### PR DESCRIPTION
This change modifies the "extraEnv" Helm value of the different workloads from an array of name/value to an object, so that it's possible to override individual environment variables by using multiple Helm values files.

It also disables OTEL SDK in CI environment from the "chart-ci-values.yaml" file instead of the CI workflow.