### PR TITLE
fix(backend): Incorrect target accounts in some sample data transactions

### DIFF
--- a/backend/internal/server/sample/acme-accounts.yaml
+++ b/backend/internal/server/sample/acme-accounts.yaml
@@ -5,7 +5,7 @@ accounts:
     children:
       - id: microsoft
         outgoingTransactions:
-          - targetAccountID: bankOfAmerica
+          - targetAccountID: primaryCheckingAccount
             date: '{{ now | dateModify "-4mo" | rfc3339 }}'
             amount: 25000
             description: Salary
@@ -14,7 +14,7 @@ accounts:
               count: 4
       - id: amazon
         outgoingTransactions:
-          - targetAccountID: bankOfAmerica
+          - targetAccountID: primaryCheckingAccount
             date: '{{ now | dateModify "-8mo" | rfc3339 }}'
             amount: 30000
             description: Salary
@@ -23,7 +23,7 @@ accounts:
               count: 4
       - id: google
         outgoingTransactions:
-          - targetAccountID: bankOfAmerica
+          - targetAccountID: primaryCheckingAccount
             date: '{{ now | dateModify "-12mo" | rfc3339 }}'
             amount: 20000
             description: Salary


### PR DESCRIPTION
This change fixes some transactions in the sample data set that used the wrong target account. Specifically, the salaries transactions targeted the Bank Of America account instead of the user's primary checking account.

Fixes #225 