### PR TITLE
feat(tests): Support providing CLI args to the `test` task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -341,7 +341,7 @@ tasks:
     deps: [ toolchain:node ]
     dir: e2e
     cmds:
-      - npx playwright test --headed
+      - npx playwright test {{.CLI_ARGS}}
 
   test-report:
     deps: [ toolchain:node ]


### PR DESCRIPTION
This change allows the following CLI:

```shell
$ task test -- --headed --timeout=0
```

By utilizing the Taskfile support for CLI args usage in tasks, anything coming after the `--` sign will be passed directly to the `npx playwright test` command.