### PR TITLE
chore(backend): Implicitly use the default logger

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -94,9 +94,9 @@ func (e *Action) Run(ctx context.Context) error {
 	// Wait for either one of the HTTP servers to prematurely exit, or an OS interrupt signal
 	select {
 	case name := <-stop:
-		slog.Default().ErrorContext(ctx, "One of the HTTP servers failed", "server", name)
+		slog.ErrorContext(ctx, "One of the HTTP servers failed", "server", name)
 	case <-ctx.Done():
-		slog.Default().ErrorContext(ctx, "Interrupt signal received")
+		slog.ErrorContext(ctx, "Interrupt signal received")
 	}
 
 	// Gracefully shutdown all HTTP servers
@@ -113,7 +113,7 @@ func (e *Action) Run(ctx context.Context) error {
 }
 
 func (e *Action) startHTTPServer(ctx context.Context, stopChan chan string, errChan chan error, name string, server *http.Server) {
-	slog.Default().DebugContext(ctx, "Starting HTTP server", "server", name)
+	slog.DebugContext(ctx, "Starting HTTP server", "server", name)
 	if err := server.ListenAndServe(); lang.IgnoreErrorOfType(err, http.ErrServerClosed) != nil {
 		errChan <- fmt.Errorf("%s server failed: %w", name, err)
 		stopChan <- name

--- a/backend/cmd/jobs/init/main.go
+++ b/backend/cmd/jobs/init/main.go
@@ -58,7 +58,7 @@ func (e *Action) Run(ctx context.Context) error {
 	defer pgPool.Close()
 
 	// Wait for PostgreSQL to be ready
-	slog.Default().InfoContext(ctx, "Waiting for Postgres connection pool to become available")
+	slog.InfoContext(ctx, "Waiting for Postgres connection pool to become available")
 	pgPingInterval := 3 * time.Second
 	timer := time.NewTimer(2 * time.Minute)
 	defer timer.Stop()
@@ -73,7 +73,7 @@ func (e *Action) Run(ctx context.Context) error {
 			return fmt.Errorf("timed out waiting for Postgres connection pool to become available")
 		case <-ticker.C:
 			if err := pgPool.Ping(ctx); err != nil {
-				slog.Default().InfoContext(ctx, "PostgreSQL not yet available", "err", err)
+				slog.InfoContext(ctx, "PostgreSQL not yet available", "err", err)
 			} else {
 				pgAvailable = true
 			}
@@ -122,7 +122,7 @@ func (e *Action) Run(ctx context.Context) error {
 			return err
 		}
 	} else {
-		slog.Default().WarnContext(ctx, "Sample data generation has been DISABLED")
+		slog.WarnContext(ctx, "Sample data generation has been DISABLED")
 	}
 
 	// Ensure fill-in any missing rates
@@ -145,7 +145,7 @@ func (e *Action) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed creating Kubernetes client: %w", err)
 		}
-		slog.Default().InfoContext(ctx, "Un-suspending the exchange-rates cron-job")
+		slog.InfoContext(ctx, "Un-suspending the exchange-rates cron-job")
 		err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 			cronJob, err := clientset.BatchV1().CronJobs(e.Namespace).Get(ctx, e.ExchangeRatesCronJobName, metav1.GetOptions{})
 			if err != nil {

--- a/backend/internal/migration/fetch_currencies.go
+++ b/backend/internal/migration/fetch_currencies.go
@@ -57,7 +57,7 @@ func (m *exchangeRatesManagerImpl) PopulateCurrencies(ctx context.Context) error
 	ctx, span := observability.Trace(ctx, trace.SpanKindServer)
 	defer span.End()
 
-	slog.Default().InfoContext(ctx, "Updating system currencies")
+	slog.InfoContext(ctx, "Updating system currencies")
 
 	staleCurrencies, err := m.fetchMissingOrStaleCurrencies(ctx)
 	if err != nil {

--- a/backend/internal/migration/fetch_current_rates.go
+++ b/backend/internal/migration/fetch_current_rates.go
@@ -27,7 +27,7 @@ func (m *exchangeRatesManagerImpl) UpdateExchangeRatesForToday(ctx context.Conte
 	ctx, span := observability.Trace(ctx, trace.SpanKindServer)
 	defer span.End()
 
-	slog.Default().DebugContext(ctx, "Updating today's exchange rates")
+	slog.DebugContext(ctx, "Updating today's exchange rates")
 
 	// Fetch currencies
 	rows, err := m.pool.Query(ctx, "SELECT code FROM currencies ORDER BY code")

--- a/backend/internal/migration/fetch_historical_rates.go
+++ b/backend/internal/migration/fetch_historical_rates.go
@@ -55,7 +55,7 @@ func (m *exchangeRatesManagerImpl) PopulateHistoricalRates(ctx context.Context, 
 	ctx, span := observability.Trace(ctx, trace.SpanKindServer)
 	defer span.End()
 
-	slog.Default().InfoContext(ctx, "Populating historical exchange rates", "period", string(period))
+	slog.InfoContext(ctx, "Populating historical exchange rates", "period", string(period))
 
 	client, err := storage.NewClient(ctx)
 	if err != nil {
@@ -105,7 +105,7 @@ func (m *exchangeRatesManagerImpl) PopulateHistoricalRates(ctx context.Context, 
 
 			recordNumber++
 			if recordNumber%1_000_000 == 0 {
-				slog.Default().DebugContext(ctx, "Progressing in reading of historical exchange rates", "records", recordNumber)
+				slog.DebugContext(ctx, "Progressing in reading of historical exchange rates", "records", recordNumber)
 			}
 
 			r, err := newRateRecord(recordNumber, rec)
@@ -163,7 +163,7 @@ func (m *exchangeRatesManagerImpl) PopulateHistoricalRates(ctx context.Context, 
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	slog.Default().DebugContext(ctx, "Populated historical exchange rates", "records", copiedRowsCount)
+	slog.DebugContext(ctx, "Populated historical exchange rates", "records", copiedRowsCount)
 
 	return nil
 }
@@ -187,7 +187,7 @@ func fetchExchangeRatesForCurrency(ctx context.Context, pool *pgxpool.Pool, curr
 		go func(ctx context.Context, pool *pgxpool.Pool, currencyApiKey, currencyCode string, year int) {
 			defer wg.Done()
 			if err := fetchExchangeRatesForCurrencyForYear(ctx, pool, currencyApiKey, currencyCode, currencyCodes, year); err != nil {
-				slog.Default().WarnContext(ctx, "Failed fetching historical exchange rates", "currency", currencyCode, "year", year, "err", err)
+				slog.WarnContext(ctx, "Failed fetching historical exchange rates", "currency", currencyCode, "year", year, "err", err)
 			}
 		}(ctx, pool, currencyApiKey, currencyCode, year)
 	}
@@ -197,7 +197,7 @@ func fetchExchangeRatesForCurrency(ctx context.Context, pool *pgxpool.Pool, curr
 }
 
 func fetchExchangeRatesForCurrencyForYear(ctx context.Context, pool *pgxpool.Pool, currencyApiKey, currencyCode string, currencies []string, year int) error {
-	slog.Default().InfoContext(ctx, "Fetching historical exchange rates", "currency", currencyCode, "year", year, "currencies", currencies)
+	slog.InfoContext(ctx, "Fetching historical exchange rates", "currency", currencyCode, "year", year, "currencies", currencies)
 
 	tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {

--- a/backend/internal/migration/fetch_missing_rates.go
+++ b/backend/internal/migration/fetch_missing_rates.go
@@ -36,7 +36,7 @@ func (m *exchangeRatesManagerImpl) PopulateMissingExchangeRates(ctx context.Cont
 	ctx, span := observability.Trace(ctx, trace.SpanKindServer)
 	defer span.End()
 
-	slog.Default().InfoContext(ctx, "Searching for missing historical exchange rates based on existing transactions")
+	slog.InfoContext(ctx, "Searching for missing historical exchange rates based on existing transactions")
 
 	rows, err := m.pool.Query(ctx, fetchMissingRatesSQL)
 	if err != nil {
@@ -56,7 +56,7 @@ func (m *exchangeRatesManagerImpl) PopulateMissingExchangeRates(ctx context.Cont
 		return nil
 	}
 
-	slog.Default().DebugContext(ctx, "Found missing exchange rates - obtaining current quotes", "missingCount", len(missingRates))
+	slog.DebugContext(ctx, "Found missing exchange rates - obtaining current quotes", "missingCount", len(missingRates))
 	for _, r := range missingRates {
 		if err := m.fetchExchangeRates(ctx, r); err != nil {
 			return fmt.Errorf("failed processing missing rate '%+v': %w", r, err)

--- a/backend/internal/migration/migrator.go
+++ b/backend/internal/migration/migrator.go
@@ -25,7 +25,7 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) (result error) {
 	ctx, span := observability.Trace(ctx, trace.SpanKindServer)
 	defer span.End()
 
-	slog.Default().InfoContext(ctx, "Verifying and potentially upgrading database schema")
+	slog.InfoContext(ctx, "Verifying and potentially upgrading database schema")
 
 	sourceDriver, err := iofs.New(fs, "schema")
 	if err != nil {

--- a/backend/internal/server/sample/sample_data.go
+++ b/backend/internal/server/sample/sample_data.go
@@ -38,7 +38,7 @@ type generator struct {
 }
 
 func Generate(ctx context.Context, descopeClient *client.DescopeClient, accessKey string, pool *pgxpool.Pool, th tenant.Handler, tenantID, tenantDisplayName string, txh transaction.Handler, ah account.Handler) error {
-	slog.Default().InfoContext(ctx, "Generating sample data")
+	slog.InfoContext(ctx, "Generating sample data")
 
 	// Exchange an access key for a token and expose it in a context, simulating the way it's done in real HTTP requests
 	_, token, err := descopeClient.Auth.ExchangeAccessKey(ctx, accessKey, nil)
@@ -82,7 +82,7 @@ func Generate(ctx context.Context, descopeClient *client.DescopeClient, accessKe
 }
 
 func generateTenant(ctx context.Context, th tenant.Handler, tenantID, tenantDisplayName string, txh transaction.Handler, ah account.Handler) error {
-	slog.Default().InfoContext(ctx, "Generating sample tenant")
+	slog.InfoContext(ctx, "Generating sample tenant")
 
 	if _, err := th.Get(ctx, tenant.GetRequest{ID: tenantID}); err != nil {
 		if errors.Is(err, util.ErrNotFound) {
@@ -102,7 +102,7 @@ func generateTenant(ctx context.Context, th tenant.Handler, tenantID, tenantDisp
 }
 
 func generateAccounts(ctx context.Context, ids map[string]string, ah account.Handler, tenantID string) error {
-	slog.Default().InfoContext(ctx, "Generating sample accounts")
+	slog.InfoContext(ctx, "Generating sample accounts")
 	for _, a := range g.Accounts {
 		if err := a.applyAccount(ctx, ids, ah, tenantID, nil); err != nil {
 			return fmt.Errorf("failed applying root account '%s': %w", a.ID, err)
@@ -112,7 +112,7 @@ func generateAccounts(ctx context.Context, ids map[string]string, ah account.Han
 }
 
 func generateTransactions(ctx context.Context, ids map[string]string, th transaction.Handler, tenantID string) error {
-	slog.Default().InfoContext(ctx, "Generating sample transactions")
+	slog.InfoContext(ctx, "Generating sample transactions")
 	for _, a := range g.Accounts {
 		if err := a.applyOutgoingTransactions(ctx, ids, th, tenantID, g.DefaultCurrency); err != nil {
 			return fmt.Errorf("failed applying transactions of root account '%s': %w", a.ID, err)

--- a/backend/internal/util/db/pool.go
+++ b/backend/internal/util/db/pool.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewPostgreSQLPool(ctx context.Context) (*pgxpool.Pool, error) {
-	slog.Default().InfoContext(ctx, "Creating Postgres connection pool")
+	slog.InfoContext(ctx, "Creating Postgres connection pool")
 
 	// PostgreSQL (note that standard environment variables are used to configure connection details to Postgres)
 	// See: https://www.postgresql.org/docs/current/libpq-envars.html


### PR DESCRIPTION
This change switches uses of the default logger from explicitly referencing it to implicitly referencing it.