### PR TITLE
fix(build): Fix the Publish E2E Tests Results workflow condition

### DIFF
--- a/.github/workflows/publish-e2e-results.yaml
+++ b/.github/workflows/publish-e2e-results.yaml
@@ -16,7 +16,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-22.04
-    if: github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.outcome == 'success' || github.event.workflow_run.outcome == 'failure')
+    if: github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Incorrect condition was set for the "Publish E2E Tests Results" workflow which relied on the "outcome" property of the workflow run instead of the "conclusion" property, as the former does not exist for a workflow run.