### PR TITLE
fix(build): Attempt to fix permissions problem in Publish E2E Results workflow

### DIFF
--- a/.github/workflows/publish-e2e-results.yaml
+++ b/.github/workflows/publish-e2e-results.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     permissions:
+      actions: read
       id-token: write
     steps:
 
@@ -33,8 +34,9 @@ jobs:
           workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github-oidc
 
       - name: Download artifact
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
@@ -53,9 +55,6 @@ jobs:
 
       - run: unzip e2e-test-results.zip
         working-directory: hack
-
-      - run: ls -la
-      - run: ls -la hack
 
       - name: Upload artifact
         uses: google-github-actions/upload-cloud-storage@v2


### PR DESCRIPTION
This change attempts to fix the permissions issue encountered in the "Publish E2E Results" workflow, which can be observed here: https://github.com/arikkfir/greenstar/actions/runs/12514828641/job/34911492790

Unfortunately we cannot test the fix until this change is merged to the `main` branch, given that GitHub runs workflows triggered by the `workflow_run` event from the `main` branch only.

Specifically this change does the following:

- Upgrade the `github-script` action to v7
- Directly pass the workflow's GitHub Token
- Grant the `actions: read` permission to the job