### PR TITLE
chore(ide): Remove restrictions on 'main' branch from JetBrains settings

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -7,6 +7,11 @@
       <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>
+  <component name="GitSharedSettings">
+    <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
+      <list />
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>


### PR DESCRIPTION
This is redundant since JetBrains IDEs load GitHub branch protections anyway.