### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -131,6 +131,8 @@ jobs:
     name: Run End-to-End Tests
     runs-on: ubuntu-22.04
     needs: [ build-images, build-helm-package ]
+    permissions:
+      contents: read
     steps:
 
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/arikkfir/greenstar/security/code-scanning/7](https://github.com/arikkfir/greenstar/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the `test-e2e` job in the workflow file. This block should explicitly define the minimal permissions required for the job to function correctly. Based on the steps in the job, the `contents: read` permission is sufficient, as the job primarily reads artifacts and runs tests without modifying the repository.

The `permissions` block should be added directly under the `test-e2e` job definition, ensuring it applies only to this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
