### PR TITLE
fix(security): add permissions scope to the `verify-generated-code` job

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -7,6 +7,11 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
 defaults:
   run:
     shell: bash -exuo pipefail {0}


### PR DESCRIPTION
Fix [https://github.com/arikkfir/greenstar/security/code-scanning/22](https://github.com/arikkfir/greenstar/security/code-scanning/22)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are recommended:
- `contents: read` for accessing repository files.
- `packages: write` for uploading Docker images and Helm packages.
- `pull-requests: write` if the workflow interacts with pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
