### PR TITLE
Fix code scanning alert no. 19: Useless conditional

### DIFF
--- a/server/src/data/accounts.ts
+++ b/server/src/data/accounts.ts
@@ -207,7 +207,7 @@ export class AccountsDataAccessLayer {
     async fetchAccounts(tenantID: Tenant["id"], displayNameFilter?: string | null): Promise<Account[]> {
         const parameters: any[] = [ tenantID ]
         if (displayNameFilter) {
-            parameters.push(displayNameFilter || null)
+            parameters.push(displayNameFilter)
         }
         const res = await this.pg.query(`
                     SELECT p.tenant_id,


### PR DESCRIPTION
Potential fix for [https://github.com/arikkfir/greenstar/security/code-scanning/19](https://github.com/arikkfir/greenstar/security/code-scanning/19)

To fix the issue, we need to remove the redundant `|| null` from line 210. The `if (displayNameFilter)` condition already ensures that `displayNameFilter` is truthy before executing the block, so the fallback to `null` is unnecessary. This change will not alter the functionality of the code but will make it cleaner and easier to understand.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
