### PR TITLE
fix(ci): move GHA permissions to job level in the `verify` workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -7,11 +7,6 @@ on:
       - opened
       - synchronize
 
-permissions:
-  contents: read
-  packages: write
-  pull-requests: write
-
 defaults:
   run:
     shell: bash -exuo pipefail {0}
@@ -25,6 +20,8 @@ jobs:
       matrix:
         module: [ acme, frontend, ratesjob, server ]
       fail-fast: true
+    permissions:
+      contents: read
     steps:
 
       - name: Checkout
@@ -62,6 +59,8 @@ jobs:
       matrix:
         image: [ acme, frontend, ratesjob, server ]
       fail-fast: true
+    permissions:
+      contents: read
     steps:
 
       - name: Checkout
@@ -105,6 +104,8 @@ jobs:
       version: ${{ steps.package.outputs.version }}
     env:
       VERSION: "0.0.0+${{ github.sha }}"
+    permissions:
+      contents: read
     steps:
 
       - name: Checkout


### PR DESCRIPTION
Adjust the `verify` workflow by relocating `permissions` configuration from the workflow level to individual jobs. This aligns with the latest best practices in GitHub Actions and ensures granular permission control.