### PR TITLE
fix(ci): improve cache key handling in verify workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -82,8 +82,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.image }}
+          cache-from: |
+            type=gha,mode=max,scope=${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.number, matrix.image) || format('{0}-{1}', github.ref_name, matrix.image) }}
+            type=gha,mode=max,scope=main-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.number, matrix.image) || format('{0}-{1}', github.ref_name, matrix.image) }}
           context: ${{ matrix.image }}
           build-args: |
             VERSION=0.0.0+${{ github.sha }}


### PR DESCRIPTION
Adjust cache key logic in `verify.yaml` so that PR builds will:

1. Pull layers from a PR-dedicated cache but use the main branch's cache as a fallback.
2. Push layers to a PR-dedicated cache when the build is for a PR, and a branch-dedicated cache when the build is for a push commit (main).

This should improve performance for PR builds since they will use the main branch's layers if corresponding layers for the current PR do not exist (yet).