### PR TITLE
chore(devex): remove the devloop task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -237,16 +237,6 @@ tasks:
     cmds:
       - skaffold dev --tail=false
 
-  devloop:
-    deps: [ setup-observability, setup-sensitive-environment ]
-    cmds:
-      - |
-        while true; do
-          task dev;
-          echo "Sleeping for 10 seconds...";
-          sleep 10;
-        done
-
   test:
     deps: [ toolchain:node ]
     dir: e2e


### PR DESCRIPTION
Given the way Task handles interrupts (completely halts after the 3rd interrupt) the new `devloop` task when run inside Task is self-defeating since the third CTRL+C would just kill the whole loop anyway.

For now, removing it.