### PR TITLE
perf(build): Increase Skaffold build concurrency

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -46,7 +46,7 @@ build:
   local:
     push: false
     useBuildkit: true
-    concurrency: 1
+    concurrency: 5
 deploy:
   helm:
     releases:


### PR DESCRIPTION
Allow Skaffold to build 5 images concurrently, increasing build performance.