### PR TITLE
chore(db): switch from composite pk to single ID and unique constraint

### DIFF
--- a/deploy/chart/files/migrations/V020__rates.sql
+++ b/deploy/chart/files/migrations/V020__rates.sql
@@ -12,6 +12,6 @@ CREATE TABLE rates
     created_at           TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at           TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     rate                 NUMERIC NOT NULL,
-    CONSTRAINT pk_rates PRIMARY KEY (date, source_currency_code, target_currency_code)
+    CONSTRAINT uq_rates PRIMARY KEY (date, source_currency_code, target_currency_code)
 );
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE rates TO greenstar_server;

--- a/server/src/data/currencies.ts
+++ b/server/src/data/currencies.ts
@@ -87,7 +87,7 @@ export class CurrenciesDataAccessLayer {
         const res = await this.pg.query(`
                     INSERT INTO rates (date, source_currency_code, target_currency_code, rate)
                     VALUES ($1, $2, $3, $4)
-                    ON CONFLICT ON CONSTRAINT pk_rates DO UPDATE SET rate = $4
+                    ON CONFLICT ON CONSTRAINT uq_rates DO UPDATE SET rate = $4
             `,
             [ date, sourceCurrencyCode, targetCurrencyCode, rate ])
 


### PR DESCRIPTION
Replace `rates` composite primary key of `date`, `source_currency_code` & `target_currency_code` with a unique constraint of the same columns, and a single `id` primary key.

This enables single-column primary key which is easier to manage.