### PR TITLE
chore(db): name column validation constraints with common prefix

### DIFF
--- a/deploy/chart/files/migrations/V040__accounts.sql
+++ b/deploy/chart/files/migrations/V040__accounts.sql
@@ -9,7 +9,7 @@ CREATE TABLE accounts
     updated_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     display_name TEXT NOT NULL
         CONSTRAINT val_display_name_length CHECK (CHAR_LENGTH(display_name) > 0),
-    icon         TEXT NOT
+    icon         TEXT NOT NULL
         CONSTRAINT val_icon_length CHECK (CHAR_LENGTH(icon) > 0),
     type         TEXT,
     parent_id    TEXT,

--- a/deploy/chart/files/migrations/V040__accounts.sql
+++ b/deploy/chart/files/migrations/V040__accounts.sql
@@ -7,8 +7,10 @@ CREATE TABLE accounts
     id           TEXT NOT NULL            DEFAULT gen_random_uuid(),
     created_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    display_name TEXT NOT NULL CHECK (CHAR_LENGTH(display_name) > 0),
-    icon         TEXT NOT NULL CHECK (CHAR_LENGTH(icon) > 0),
+    display_name TEXT NOT NULL
+        CONSTRAINT val_display_name_length CHECK (CHAR_LENGTH(display_name) > 0),
+    icon         TEXT NOT
+        CONSTRAINT val_icon_length CHECK (CHAR_LENGTH(icon) > 0),
     type         TEXT,
     parent_id    TEXT,
     PRIMARY KEY (tenant_id, id),

--- a/deploy/chart/files/migrations/V050__transactions.sql
+++ b/deploy/chart/files/migrations/V050__transactions.sql
@@ -10,11 +10,13 @@ CREATE TABLE transactions
     date              TIMESTAMP WITH TIME ZONE,
     reference_id      TEXT       NOT NULL,
     amount            NUMERIC    NOT NULL CHECK (amount > 0),
-    currency          VARCHAR(5) NOT NULL CHECK (CHAR_LENGTH(currency) = 3)
+    currency          VARCHAR(5) NOT NULL
+        CONSTRAINT val_currency_not_empty CHECK (CHAR_LENGTH(currency) = 3)
         CONSTRAINT fk_transactions_currency
             REFERENCES currencies
             ON UPDATE CASCADE ON DELETE RESTRICT,
-    description       TEXT CHECK (CHAR_LENGTH(description) > 0),
+    description       TEXT
+        CONSTRAINT val_description_not_empty CHECK (CHAR_LENGTH(description) > 0),
     source_account_id TEXT       NOT NULL,
     target_account_id TEXT       NOT NULL,
     PRIMARY KEY (tenant_id, id),


### PR DESCRIPTION
Ensure all column validation constraints start with the `val_` prefix.