### PR TITLE
feat(gcp): add GCP integration for local kind cluster

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -30,7 +30,6 @@ tasks:
       - generate-graphql-acme
       - generate-graphql-frontend
       - generate-graphql-ratesjob
-      - generate-graphql-scrapers
       - generate-graphql-server
       - generate-certificates
 
@@ -53,13 +52,6 @@ tasks:
     dir: ratesjob
     cmds:
       - rm -rfv src/graphql
-      - npm run codegen
-
-  generate-graphql-scrapers:
-    deps: [ toolchain:node ]
-    dir: scrapers
-    cmds:
-      - rm -rfv src/generated
       - npm run codegen
 
   generate-graphql-server:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -30,6 +30,7 @@ tasks:
       - generate-graphql-acme
       - generate-graphql-frontend
       - generate-graphql-ratesjob
+      - generate-graphql-scrapers
       - generate-graphql-server
       - generate-certificates
 
@@ -52,6 +53,13 @@ tasks:
     dir: ratesjob
     cmds:
       - rm -rfv src/graphql
+      - npm run codegen
+
+  generate-graphql-scrapers:
+    deps: [ toolchain:node ]
+    dir: scrapers
+    cmds:
+      - rm -rfv src/generated
       - npm run codegen
 
   generate-graphql-server:
@@ -94,8 +102,6 @@ tasks:
       - kubectl get namespace -o=name | grep -qE "^namespace/observability$"
 
   setup-gateway:
-    aliases:
-      - setup-cluster
     deps: [ create-cluster, generate-certificates ]
     cmds:
       - |
@@ -202,7 +208,7 @@ tasks:
 
   setup-observability:
     deps:
-      - setup-cluster
+      - setup-gateway
       - setup-kube-state-metrics
       - setup-metrics-server
       - setup-prometheus-node-exporter
@@ -210,31 +216,116 @@ tasks:
       - setup-jaeger
       - setup-grafana
 
-  setup-sensitive-environment:
+  setup-tenant-helm-values-files:
+    sources:
+      - ./deploy/local/acme/*.yaml
+    generates:
+      - ./hack/greenstar-tenants-values.yaml
     cmds:
-      - touch ./hack/greenstar-values.yaml
-      - yq -i '.frontend.extraEnv.VITE_GEOAPIFY_API_KEY.value = env(GEOAPIFY_API_KEY)' ./hack/greenstar-values.yaml
-      - yq -i '.acme.files = []' ./hack/greenstar-values.yaml
+      - # noinspection YAMLSchemaValidation
+        for: sources
+        cmd: |
+          mkdir -pv ./hack && touch ./hack/greenstar-tenants-values.yaml
+          NAME="$(basename "{{ .ITEM }}")" CONTENT="$(cat "{{ .ITEM }}")" \
+            yq -i '.acme.files += [{"name": env(NAME), "content": env(CONTENT)}]' ./hack/greenstar-tenants-values.yaml
+
+  setup-frontend-geopify-helm-values-files:
+    cmds:
+      - mkdir -pv ./hack && touch ./hack/greenstar-frontend-values.yaml
+      - yq -i '.frontend.extraEnv.VITE_GEOAPIFY_API_KEY.value = strenv(GEOAPIFY_API_KEY)' ./hack/greenstar-frontend-values.yaml
+    status:
+      - yq -e '.frontend.extraEnv.VITE_GEOAPIFY_API_KEY.value == strenv(GEOAPIFY_API_KEY)' ./hack/greenstar-frontend-values.yaml
+
+  enable-gcp-workload-identity-federation:
+    deps: [create-cluster]
+    env:
+      WHOAMI:
+        sh: whoami
+      ATTRIBUTE_MAPPINGS: google.subject=assertion.sub,attribute.namespace=assertion['kubernetes.io']['namespace'],attribute.service_account_name=assertion['kubernetes.io']['serviceaccount']['name'],attribute.pod=assertion['kubernetes.io']['pod']['name']
+      CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+      GCP_PROJECT_ID:
+        sh: gcloud config get-value project
+      GCP_PROJECT_NUMBER:
+        sh: gcloud projects describe ${GCP_PROJECT_ID} --format="value(projectNumber)"
+      GCP_WORKLOAD_IDENTITY_POOL: greenstar
+      GCP_WORKLOAD_IDENTITY_PROVIDER_ID:
+        sh: echo -n local-kind-jwks-${WHOAMI}
+      OIDC_AUDIENCE:
+        sh: echo -n https://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/greenstar/providers/local-kind-jwks-${WHOAMI}
+      POD_ADC_FILE_PATH: /etc/workload-identity/credential-configuration.json
+    cmds:
       - |
-        for filepath in ./deploy/local/acme/*.yaml; do
-          NAME="$(basename "$filepath")" CONTENT="$(cat "$filepath")" yq -i \
-            '.acme.files += [{"name": env(NAME), "content": env(CONTENT)}]' \
-            ./hack/greenstar-values.yaml
-        done
-
-  deploy:
-    deps: [ setup-observability, setup-sensitive-environment ]
-    cmds:
-      - skaffold build -q > hack/skaffold-build.json
-      - skaffold deploy --load-images --build-artifacts hack/skaffold-build.json
-
-  undeploy:
-    cmds:
-      - skaffold delete
+        mkdir -pv hack
+        kubectl get --raw /openid/v1/jwks > hack/cluster-jwks.json
+        kubectl get --raw /.well-known/openid-configuration | jq -r .issuer > hack/cluster-oidc-issuer
+        if ! gcloud iam workload-identity-pools describe "${GCP_WORKLOAD_IDENTITY_POOL}" --location="global" 2>/dev/null; then
+          gcloud iam workload-identity-pools create greenstar \
+            --location="global" \
+            --description="Workload Identity Pool for GreenSTAR" \
+            --display-name="GreenSTAR";
+        fi
+        if ! gcloud iam workload-identity-pools providers describe --location="global" --workload-identity-pool="${GCP_WORKLOAD_IDENTITY_POOL}" "${GCP_WORKLOAD_IDENTITY_PROVIDER_ID}" 2>/dev/null; then
+          gcloud iam workload-identity-pools providers create-oidc "${GCP_WORKLOAD_IDENTITY_PROVIDER_ID}" \
+            --location="global" \
+            --workload-identity-pool="${GCP_WORKLOAD_IDENTITY_POOL}" \
+            --issuer-uri="$(cat hack/cluster-oidc-issuer)" \
+            --jwk-json-path="hack/cluster-jwks.json" \
+            --allowed-audiences="" \
+            --attribute-mapping="${ATTRIBUTE_MAPPINGS}"
+        else
+          gcloud iam workload-identity-pools providers update-oidc "${GCP_WORKLOAD_IDENTITY_PROVIDER_ID}" \
+            --location="global" \
+            --workload-identity-pool="${GCP_WORKLOAD_IDENTITY_POOL}" \
+            --issuer-uri="$(cat hack/cluster-oidc-issuer)" \
+            --jwk-json-path="hack/cluster-jwks.json" \
+            --allowed-audiences="" \
+            --attribute-mapping="${ATTRIBUTE_MAPPINGS}"
+        fi
+        gcloud iam workload-identity-pools create-cred-config \
+          "projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${GCP_WORKLOAD_IDENTITY_POOL}/providers/${GCP_WORKLOAD_IDENTITY_PROVIDER_ID}" \
+          --credential-source-file=/var/run/service-account/token \
+          --credential-source-type=text \
+          --output-file=hack/credential-configuration.json
+        kubectl get namespace greenstar || kubectl create namespace greenstar
+        kubectl delete configmap -n greenstar gcp-workload-identity-federation || true
+        kubectl create configmap -n greenstar gcp-workload-identity-federation --from-file hack/credential-configuration.json
+        mkdir -pv ./hack && touch ./hack/greenstar-server-values.yaml
+        yq -i '.server.volumes = [], .server.volumeMounts = []' ./hack/greenstar-server-values.yaml
+        echo ${GCP_PROJECT_ID}
+        cat <<EOF | yq -i ea 'select(fileIndex == 0) *+ select(fileIndex == 1)' ./hack/greenstar-server-values.yaml -
+        server:
+          extraEnv:
+            GCP_PROJECT_ID:
+              value: "${GCP_PROJECT_ID}"
+            GOOGLE_APPLICATION_CREDENTIALS:
+              value: "${POD_ADC_FILE_PATH}"
+          volumeMounts:
+            - name: token
+              mountPath: /var/run/service-account
+              readOnly: true
+            - name: workload-identity-credential-configuration
+              mountPath: /etc/workload-identity
+              readOnly: true
+          volumes:
+            - name: token
+              projected:
+                sources:
+                  - serviceAccountToken:
+                      audience: "${OIDC_AUDIENCE}"
+                      expirationSeconds: 3600
+                      path: token
+            - name: workload-identity-credential-configuration
+              configMap:
+                name: gcp-workload-identity-federation
+        EOF
 
   dev:
-    deps: [ setup-observability, setup-sensitive-environment ]
+    deps:
+      - setup-observability
+      - setup-tenant-helm-values-files
+      - setup-frontend-geopify-helm-values-files
     cmds:
+      - '[[ -f ./hack/greenstar-server-values.yaml ]] || (mkdir -pv hack && touch ./hack/greenstar-server-values.yaml)'
       - skaffold dev --tail=false
 
   test:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -60,7 +60,9 @@ deploy:
         upgradeOnChange: true
         valuesFiles:
           - deploy/local/chart-local-values.yaml
-          - hack/greenstar-values.yaml
+          - hack/greenstar-frontend-values.yaml
+          - hack/greenstar-server-values.yaml
+          - hack/greenstar-tenants-values.yaml
         setValueTemplates:
           acme:
             image:


### PR DESCRIPTION
Enable workloads running in the local `kind` cluster to have a GCP workload identity by integrating an OIDC provider with your GCP project.

To enable:

1. Ensure you are authenticated to your GCP project by running:
   
   ```shell
   $ gcloud auth print-access-token
   $ gcloud config get-value project
   ```

2. Enable GCP for the local kind cluster:

   ```shell
   $ task enable-gcp-workload-identity-federation
   ```