### PR TITLE
fix(db): add missing PK and fix naming mismatch of UQ constraint

### DIFF
--- a/deploy/chart/files/migrations/V020__rates.sql
+++ b/deploy/chart/files/migrations/V020__rates.sql
@@ -1,5 +1,6 @@
 CREATE TABLE rates
 (
+    id                   TEXT    NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
     date                 DATE    NOT NULL,
     source_currency_code TEXT    NOT NULL
         CONSTRAINT fk_rates_source_currency_code
@@ -12,6 +13,6 @@ CREATE TABLE rates
     created_at           TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at           TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     rate                 NUMERIC NOT NULL,
-    CONSTRAINT uq_rates PRIMARY KEY (date, source_currency_code, target_currency_code)
+    CONSTRAINT uq_rates UNIQUE (date, source_currency_code, target_currency_code)
 );
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE rates TO greenstar_server;


### PR DESCRIPTION
Incomplete change in previous commit that renamed the primary key of the `rates` table from `pk_rates` to `uq_rates`, but kept it defined as `PRIMARY KEY`.

This change finishes the job by updating it to its correct type: `UNIQUE` and adds an `id` primary key column.