### PR TITLE
fix(ci): disable OTEL SDK in the server pods in the CI environment

### DIFF
--- a/deploy/local/chart-ci-values.yaml
+++ b/deploy/local/chart-ci-values.yaml
@@ -10,6 +10,9 @@ server:
       namespace: ingress
       httpSectionName: web
       httpsSectionName: websecure
+  extraEnv:
+    OTEL_SDK_DISABLED:
+      value: "true"
 
 ratesjob:
   schedule: "0 * * * *"


### PR DESCRIPTION
This prevents OTEL failures in CI since no Jaeger instance is set up in CI clusters.