### PR TITLE
feat(c): allow job pods inspections post CI failures

### DIFF
--- a/deploy/chart/templates/cleanup.tpl.yaml
+++ b/deploy/chart/templates/cleanup.tpl.yaml
@@ -58,6 +58,7 @@ subjects:
 
 ---
 
+{{- if or.Values.cleanup.cronjobs .Values.cleanup.jobs }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -88,8 +89,8 @@ spec:
             - /bin/sh
             - -c
             - |
-              kubectl delete cronjobs -n ${NS} -l ${SELECTOR} --ignore-not-found=true --wait
-              kubectl delete jobs -n ${NS} -l ${SELECTOR} --ignore-not-found=true --wait
+              {{- if .Values.cleanup.cronjobs }}kubectl delete cronjobs -n ${NS} -l ${SELECTOR} --ignore-not-found=true --wait{{- end }}
+              {{- if .Values.cleanup.jobs }}kubectl delete jobs -n ${NS} -l ${SELECTOR} --ignore-not-found=true --wait{{- end }}
           resources:
             limits:
               cpu: 500m
@@ -100,3 +101,4 @@ spec:
       restartPolicy: Never
       enableServiceLinks: false
       serviceAccountName: {{ $serviceAccountName | quote }}
+{{- end }}

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -3,6 +3,17 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "cleanup": {
+            "type": "object",
+            "properties": {
+                "cronjobs": {
+                    "type": "boolean"
+                },
+                "jobs": {
+                    "type": "boolean"
+                }
+            }
+        },
         "ingress": {
             "type": "object",
             "additionalProperties": false,

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,3 +1,6 @@
+cleanup:
+  cronjobs: true
+  jobs: true
 ingress:
   domain: ""
 acme:

--- a/deploy/local/chart-ci-values.yaml
+++ b/deploy/local/chart-ci-values.yaml
@@ -1,3 +1,6 @@
+cleanup:
+  cronjobs: false
+  jobs: false
 ingress:
   domain: greenstar.test
 


### PR DESCRIPTION
Disable jobs cleanup in the CI environments, allowing inspection of pods even when the Helm chart fails to install.