### PR TITLE
feat(server): add transaction field resolver and supporting methods

### DIFF
--- a/acme/src/graphql/graphql.ts
+++ b/acme/src/graphql/graphql.ts
@@ -324,6 +324,7 @@ export type Tenant = {
   rootAccounts: Array<Account>;
   scrapers: Array<Scraper>;
   totalTransactions: Scalars['Int']['output'];
+  transaction?: Maybe<Transaction>;
   transactions: TransactionsResult;
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -344,6 +345,11 @@ export type TenantAccountsBalanceOverTimeArgs = {
   currency: Scalars['String']['input'];
   endDate?: InputMaybe<Scalars['DateTime']['input']>;
   startDate?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+
+export type TenantTransactionArgs = {
+  id: Scalars['ID']['input'];
 };
 
 

--- a/frontend/src/graphql/graphql.ts
+++ b/frontend/src/graphql/graphql.ts
@@ -324,6 +324,7 @@ export type Tenant = {
   rootAccounts: Array<Account>;
   scrapers: Array<Scraper>;
   totalTransactions: Scalars['Int']['output'];
+  transaction?: Maybe<Transaction>;
   transactions: TransactionsResult;
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -344,6 +345,11 @@ export type TenantAccountsBalanceOverTimeArgs = {
   currency: Scalars['String']['input'];
   endDate?: InputMaybe<Scalars['DateTime']['input']>;
   startDate?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+
+export type TenantTransactionArgs = {
+  id: Scalars['ID']['input'];
 };
 
 

--- a/ratesjob/src/graphql/graphql.ts
+++ b/ratesjob/src/graphql/graphql.ts
@@ -324,6 +324,7 @@ export type Tenant = {
   rootAccounts: Array<Account>;
   scrapers: Array<Scraper>;
   totalTransactions: Scalars['Int']['output'];
+  transaction?: Maybe<Transaction>;
   transactions: TransactionsResult;
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -344,6 +345,11 @@ export type TenantAccountsBalanceOverTimeArgs = {
   currency: Scalars['String']['input'];
   endDate?: InputMaybe<Scalars['DateTime']['input']>;
   startDate?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+
+export type TenantTransactionArgs = {
+  id: Scalars['ID']['input'];
 };
 
 

--- a/server/src/data/data_layer.ts
+++ b/server/src/data/data_layer.ts
@@ -147,6 +147,8 @@ export interface DataLayer {
 
     fetchTenant(id: Tenant["id"]): Promise<Tenant | null>
 
+    fetchTransaction(tenantID: Tenant["id"], txID: Transaction["id"]): Promise<Transaction | null>
+
     fetchTransactions(tenantID: Tenant["id"],
         direction: TransactionsKey["direction"],
         args: TenantTransactionsArgs): Promise<TransactionsResult>
@@ -267,6 +269,10 @@ export class NoOpDataLayer {
     }
 
     fetchScraperTypeParameters(scraperTypeID: ScraperType["id"]): Promise<ScraperTypeParameter[]> {
+        throw new Error("Not implemented")
+    }
+
+    fetchTransaction(_tenantID: Tenant["id"], _txID: Transaction["id"]): Promise<Transaction | null> {
         throw new Error("Not implemented")
     }
 
@@ -746,6 +752,10 @@ export class DataLayerImpl implements DataLayer {
 
     async fetchTenant(id: Tenant["id"]): Promise<Tenant | null> {
         return this.tenant.load(id)
+    }
+
+    async fetchTransaction(tenantID: Tenant["id"], txID: Transaction["id"]): Promise<Transaction | null> {
+        return await this.transaction.load({tenantID, txID})
     }
 
     async fetchTransactions(

--- a/server/src/resolvers.ts
+++ b/server/src/resolvers.ts
@@ -10,6 +10,7 @@ import {
     ScraperType,
     ScraperTypeParameter,
     Tenant,
+    Transaction,
 } from "./schema/graphql.js"
 import { DateTimeScalar } from "./schema/scalars-luxon-datetime.js"
 import { VoidScalar } from "./schema/scalars-void.js"
@@ -142,6 +143,8 @@ export const GraphResolvers: Resolvers<Context> = {
             return summary.totalCount
         },
         scrapers: async (tenant, _args, ctx) => ctx.data.fetchScrapers(tenant.id),
+        transaction: async (tenant, args, ctx): Promise<Transaction | null> => ctx.data.fetchTransaction(tenant.id,
+            args.id),
     },
     Account: {
         parent: async (account, _args: any, ctx) => ctx.data.fetchAccount(

--- a/server/src/schema/graphql.ts
+++ b/server/src/schema/graphql.ts
@@ -325,6 +325,7 @@ export type Tenant = {
   rootAccounts: Array<Account>;
   scrapers: Array<Scraper>;
   totalTransactions: Scalars['Int']['output'];
+  transaction?: Maybe<Transaction>;
   transactions: TransactionsResult;
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -345,6 +346,11 @@ export type TenantAccountsBalanceOverTimeArgs = {
   currency: Scalars['String']['input'];
   endDate?: InputMaybe<Scalars['DateTime']['input']>;
   startDate?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+
+export type TenantTransactionArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -679,6 +685,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   rootAccounts?: Resolver<Array<ResolversTypes['Account']>, ParentType, ContextType>;
   scrapers?: Resolver<Array<ResolversTypes['Scraper']>, ParentType, ContextType>;
   totalTransactions?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  transaction?: Resolver<Maybe<ResolversTypes['Transaction']>, ParentType, ContextType, RequireFields<TenantTransactionArgs, 'id'>>;
   transactions?: Resolver<ResolversTypes['TransactionsResult'], ParentType, ContextType, Partial<TenantTransactionsArgs>>;
   updatedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/server/src/schema/tenants.graphql
+++ b/server/src/schema/tenants.graphql
@@ -25,6 +25,7 @@ type Tenant {
     firstTransactionDate: DateTime
     lastTransactionDate: DateTime
     totalTransactions: Int!
+    transaction(id: ID!): Transaction
     transactions(
         since: DateTime
         until: DateTime


### PR DESCRIPTION
Introduce a new `transaction` field in the `Tenant` type within the GraphQL schema and implement its resolver. This enables fetching a specific transaction by its ID.

Changes include:
- Updates to the GraphQL schema to define the `transaction` field and corresponding arguments.
- Addition of the `fetchTransaction` method to the `data_layer` interface and its implementations.
- Schema updates across `server`, `acme`, `ratesjob`, and `frontend` to support the `transaction` resolver.